### PR TITLE
Use hunspell-sys crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["spellcheck", "hunspell"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/lipk/hunspell-rust"
+edition = "2018"
 
 [dependencies]
 hunspell-sys = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ readme = "README.md"
 repository = "https://github.com/lipk/hunspell-rust"
 
 [dependencies]
+hunspell-sys = "0.1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-extern crate hunspell_sys;
 
 use std::ffi::{CStr, CString};
 use std::ptr::null_mut;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ extern crate hunspell_sys;
 
 use std::ffi::{CString, CStr};
 use std::ptr::null_mut;
-use std::os::raw::c_char;
 
 use hunspell_sys::*;
 
@@ -49,8 +48,6 @@ fn stem() {
     let cat_stem = hs.stem("cats");
     assert!(cat_stem[0] == "cat");
 }
-
-type CStringList = *mut *mut i8;
 
 pub struct Hunspell {
     handle: *mut Hunhandle

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,13 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+extern crate hunspell_sys;
 
 use std::ffi::{CString, CStr};
 use std::ptr::null_mut;
 use std::os::raw::c_char;
+
+use hunspell_sys::*;
 
 #[test]
 fn create_and_destroy() {
@@ -45,31 +48,6 @@ fn stem() {
                            "/usr/share/hunspell/en_US.dic");
     let cat_stem = hs.stem("cats");
     assert!(cat_stem[0] == "cat");
-}
-
-enum Hunhandle {}
-
-#[link(name = "hunspell")]
-extern {
-    fn Hunspell_create(affpath: *const i8, dpath: *const i8) -> *mut Hunhandle;
-    fn Hunspell_create_key(affpath: *const i8, dpath: *const i8, key: *const i8) -> *mut Hunhandle;
-    fn Hunspell_destroy(pHunspell: *mut Hunhandle);
-
-    fn Hunspell_spell(pHunspell: *mut Hunhandle, word: *const i8) -> i32;
-    fn Hunspell_get_dic_encoding(pHunspell: *mut Hunhandle) -> *mut i8;
-
-    fn Hunspell_suggest(pHunspell: *mut Hunhandle, slst: *mut *mut *mut i8, word: *const i8) -> i32;
-    fn Hunspell_analyze(pHunspell: *mut Hunhandle, slst: *mut *mut *mut i8, word: *const i8) -> i32;
-    fn Hunspell_stem(pHunspell: *mut Hunhandle, slst: *mut *mut *mut i8, word: *const i8) -> i32;
-    fn Hunspell_stem2(pHunspell: *mut Hunhandle, slst: *mut *mut *mut i8, desc: *mut *mut i8, n: i32) -> i32;
-    fn Hunspell_generate(pHunspell: *mut Hunhandle, slst: *mut *mut *mut i8, word: *const i8, word2: *const i8) -> i32;
-    fn Hunspell_generate2(pHunspell: *mut Hunhandle, slst: *mut *mut *mut i8, word: *const i8, desc: *mut *mut i8, n: i32) -> i32;
-
-    fn Hunspell_add(pHunspell: *mut Hunhandle, word: *const i8) -> i32;
-    fn Hunspell_add_with_affix(pHunspell: *mut Hunhandle, word: *const i8, example: *const i8) -> i32;
-    fn Hunspell_remove(pHunspell: *mut Hunhandle, slst: *mut *mut *mut i8, n: i32) -> i32;
-
-    fn Hunspell_free_list(pHunspell: *mut Hunhandle, slst: *mut *mut *mut i8, n: i32);
 }
 
 type CStringList = *mut *mut i8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn create_and_destroy() {
-        let hs = Hunspell::new("tests/fixtures/reduced.aff",
+        let _hs = Hunspell::new("tests/fixtures/reduced.aff",
                                "tests/fixtures/reduced.dic");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,35 +20,6 @@ use std::ptr::null_mut;
 
 use hunspell_sys::*;
 
-#[test]
-fn create_and_destroy() {
-    let hs = Hunspell::new("tests/fixtures/reduced.aff",
-                           "tests/fixtures/reduced.dic");
-}
-
-#[test]
-fn check() {
-    let hs = Hunspell::new("tests/fixtures/reduced.aff",
-                           "tests/fixtures/reduced.dic");
-    assert!(hs.check("cats"));
-    assert!(!hs.check("nocats"));
-}
-
-#[test]
-fn suggest() {
-    let hs = Hunspell::new("tests/fixtures/reduced.aff",
-                           "tests/fixtures/reduced.dic");
-    assert!(hs.suggest("progra").len() > 0);
-}
-
-#[test]
-fn stem() {
-    let hs = Hunspell::new("tests/fixtures/reduced.aff",
-                           "tests/fixtures/reduced.dic");
-    let cat_stem = hs.stem("cats");
-    assert!(cat_stem[0] == "cat");
-}
-
 pub struct Hunspell {
     handle: *mut Hunhandle
 }
@@ -130,5 +101,39 @@ impl Drop for Hunspell {
         unsafe {
             Hunspell_destroy(self.handle);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Hunspell;
+
+    #[test]
+    fn create_and_destroy() {
+        let hs = Hunspell::new("tests/fixtures/reduced.aff",
+                               "tests/fixtures/reduced.dic");
+    }
+
+    #[test]
+    fn check() {
+        let hs = Hunspell::new("tests/fixtures/reduced.aff",
+                               "tests/fixtures/reduced.dic");
+        assert!(hs.check("cats"));
+        assert!(!hs.check("nocats"));
+    }
+
+    #[test]
+    fn suggest() {
+        let hs = Hunspell::new("tests/fixtures/reduced.aff",
+                               "tests/fixtures/reduced.dic");
+        assert!(hs.suggest("progra").len() > 0);
+    }
+
+    #[test]
+    fn stem() {
+        let hs = Hunspell::new("tests/fixtures/reduced.aff",
+                               "tests/fixtures/reduced.dic");
+        let cat_stem = hs.stem("cats");
+        assert!(cat_stem[0] == "cat");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,29 +23,29 @@ use hunspell_sys::*;
 
 #[test]
 fn create_and_destroy() {
-    let hs = Hunspell::new("/usr/share/hunspell/en_US.aff",
-                           "/usr/share/hunspell/en_US.dic");
+    let hs = Hunspell::new("tests/fixtures/reduced.aff",
+                           "tests/fixtures/reduced.dic");
 }
 
 #[test]
 fn check() {
-    let hs = Hunspell::new("/usr/share/hunspell/en_US.aff",
-                           "/usr/share/hunspell/en_US.dic");
-    assert!(hs.check("programming"));
-    assert!(!hs.check("progrmaing"));
+    let hs = Hunspell::new("tests/fixtures/reduced.aff",
+                           "tests/fixtures/reduced.dic");
+    assert!(hs.check("cats"));
+    assert!(!hs.check("nocats"));
 }
 
 #[test]
 fn suggest() {
-    let hs = Hunspell::new("/usr/share/hunspell/en_US.aff",
-                           "/usr/share/hunspell/en_US.dic");
+    let hs = Hunspell::new("tests/fixtures/reduced.aff",
+                           "tests/fixtures/reduced.dic");
     assert!(hs.suggest("progra").len() > 0);
 }
 
 #[test]
 fn stem() {
-    let hs = Hunspell::new("/usr/share/hunspell/en_US.aff",
-                           "/usr/share/hunspell/en_US.dic");
+    let hs = Hunspell::new("tests/fixtures/reduced.aff",
+                           "tests/fixtures/reduced.dic");
     let cat_stem = hs.stem("cats");
     assert!(cat_stem[0] == "cat");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,13 @@
 */
 extern crate hunspell_sys;
 
-use std::ffi::{CString, CStr};
+use std::ffi::{CStr, CString};
 use std::ptr::null_mut;
 
 use hunspell_sys::*;
 
 pub struct Hunspell {
-    handle: *mut Hunhandle
+    handle: *mut Hunhandle,
 }
 
 macro_rules! extract_vec {
@@ -50,7 +50,7 @@ impl Hunspell {
         let dicpath = CString::new(dicpath).unwrap();
         unsafe {
             Hunspell {
-                handle: Hunspell_create(affpath.as_ptr(), dicpath.as_ptr())
+                handle: Hunspell_create(affpath.as_ptr(), dicpath.as_ptr()),
             }
         }
     }
@@ -61,17 +61,14 @@ impl Hunspell {
         let key = CString::new(key).unwrap();
         unsafe {
             Hunspell {
-                handle: Hunspell_create_key(affpath.as_ptr(), dicpath.as_ptr(),
-                                            key.as_ptr())
+                handle: Hunspell_create_key(affpath.as_ptr(), dicpath.as_ptr(), key.as_ptr()),
             }
         }
     }
 
     pub fn check(&self, word: &str) -> bool {
         let word = CString::new(word).unwrap();
-        unsafe {
-            Hunspell_spell(self.handle, word.as_ptr()) == 1
-        }
+        unsafe { Hunspell_spell(self.handle, word.as_ptr()) == 1 }
     }
 
     pub fn suggest(&self, word: &str) -> Vec<String> {
@@ -92,7 +89,12 @@ impl Hunspell {
     pub fn generate(&self, word1: &str, word2: &str) -> Vec<String> {
         let word1 = CString::new(word1).unwrap();
         let word2 = CString::new(word2).unwrap();
-        extract_vec!(Hunspell_generate, self.handle, word1.as_ptr(), word2.as_ptr())
+        extract_vec!(
+            Hunspell_generate,
+            self.handle,
+            word1.as_ptr(),
+            word2.as_ptr()
+        )
     }
 }
 
@@ -110,29 +112,25 @@ mod tests {
 
     #[test]
     fn create_and_destroy() {
-        let _hs = Hunspell::new("tests/fixtures/reduced.aff",
-                               "tests/fixtures/reduced.dic");
+        let _hs = Hunspell::new("tests/fixtures/reduced.aff", "tests/fixtures/reduced.dic");
     }
 
     #[test]
     fn check() {
-        let hs = Hunspell::new("tests/fixtures/reduced.aff",
-                               "tests/fixtures/reduced.dic");
+        let hs = Hunspell::new("tests/fixtures/reduced.aff", "tests/fixtures/reduced.dic");
         assert!(hs.check("cats"));
         assert!(!hs.check("nocats"));
     }
 
     #[test]
     fn suggest() {
-        let hs = Hunspell::new("tests/fixtures/reduced.aff",
-                               "tests/fixtures/reduced.dic");
+        let hs = Hunspell::new("tests/fixtures/reduced.aff", "tests/fixtures/reduced.dic");
         assert!(hs.suggest("progra").len() > 0);
     }
 
     #[test]
     fn stem() {
-        let hs = Hunspell::new("tests/fixtures/reduced.aff",
-                               "tests/fixtures/reduced.dic");
+        let hs = Hunspell::new("tests/fixtures/reduced.aff", "tests/fixtures/reduced.dic");
         let cat_stem = hs.stem("cats");
         assert!(cat_stem[0] == "cat");
     }

--- a/tests/fixtures/reduced.aff
+++ b/tests/fixtures/reduced.aff
@@ -1,0 +1,4 @@
+SET UTF-8
+
+SFX S Y 1
+SFX S   0     s          [^sxzhy]

--- a/tests/fixtures/reduced.dic
+++ b/tests/fixtures/reduced.dic
@@ -1,0 +1,3 @@
+2
+cat/S
+program/S


### PR DESCRIPTION
Hi,

this PR:

- switches to using the hunspell-sys crate from https://github.com/euclio/hunspell-sys to deal with the lower-level details of binding to libhunspell, focusing this crate on providing a safe-rust API.

- fixes the tests to run with bundled minimal aff/dic files

